### PR TITLE
Fix purifier entity test counts after fan refactor

### DIFF
--- a/tests/unit/petsnowy/test_entity_descriptions.py
+++ b/tests/unit/petsnowy/test_entity_descriptions.py
@@ -75,7 +75,7 @@ class TestPurifierEntities:
 
     def test_has_switches(self) -> None:
         """Purifier exposes switches."""
-        assert len(_SWITCHES_BY_TYPE[DEVICE_TYPE_PURIFIER]) == 2
+        assert len(_SWITCHES_BY_TYPE[DEVICE_TYPE_PURIFIER]) == 1
 
     def test_has_binary_sensors(self) -> None:
         """Purifier exposes fault binary sensors."""
@@ -83,7 +83,7 @@ class TestPurifierEntities:
 
     def test_has_selects(self) -> None:
         """Purifier exposes select entities."""
-        assert len(_SELECTS_BY_TYPE[DEVICE_TYPE_PURIFIER]) == 3
+        assert len(_SELECTS_BY_TYPE[DEVICE_TYPE_PURIFIER]) == 1
 
 
 class TestFeederEntities:


### PR DESCRIPTION
## Summary
- Update purifier switch count assertion from 2 to 1 (fan on/off moved to fan entity)
- Update purifier select count assertion from 3 to 1 (fan speed + mode moved to fan entity)

## Test plan
- [ ] CI passes with updated test assertions